### PR TITLE
Validationfix

### DIFF
--- a/src/main/java/com/Group3/JavaSpringExam/Util/GlobalExceptionHandler.java
+++ b/src/main/java/com/Group3/JavaSpringExam/Util/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.Group3.JavaSpringExam.Util;
 
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -22,5 +24,13 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NoSuchElementException.class)
     public ResponseEntity<String> handleNoSuchElementException(NoSuchElementException exception) {
         return ResponseEntity.badRequest().body(exception.getMessage());
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<Map<String,String>> handleConstraintViolationException(ConstraintViolationException exception) {
+        Map<String, String> errors = new HashMap<>();
+        exception.getConstraintViolations().forEach(violation ->
+                errors.put(violation.getPropertyPath().toString(), violation.getMessage()));
+        return ResponseEntity.badRequest().body(errors);
     }
 }

--- a/src/main/java/com/Group3/JavaSpringExam/Util/GlobalExceptionHandler.java
+++ b/src/main/java/com/Group3/JavaSpringExam/Util/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.Group3.JavaSpringExam.Util;
 
 import jakarta.validation.ConstraintViolationException;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;


### PR DESCRIPTION
Har lagt till en constrainvalidation exception handler vilket gör att validering gäller även för böcker som man lägger till med en ny författare. Detta behövs eftersom vi inte har någon endpoint för författare, vilket innebär att valideringsfel i författare objekt plockas int upp i det vanliga validation exception handler.

